### PR TITLE
fix?: lowercase tenant,site in netbox_create_vm.py

### DIFF
--- a/netbox_create_vm.py
+++ b/netbox_create_vm.py
@@ -200,12 +200,12 @@ if vm:
   fail("VM with speicified name already exists")
 
 # find the tenant object
-tenant = nb.tenancy.tenants.get(slug=args.tenant)
+tenant = nb.tenancy.tenants.get(slug=args.tenant.lower())
 if not tenant:
   fail("no such tenant")
 
 # fint the site object
-site = nb.dcim.sites.get(slug=args.site)
+site = nb.dcim.sites.get(slug=args.site.lower())
 if not site:
   fail("no such site")
 


### PR DESCRIPTION
perhaps it is natural to write the tenant/site in lowercase, or if you know the tooling, but since these args are passed into functions as `slug=` (and matched against lowercase slugs server-side), chances are that this (.lower()) covers more cases than its absence.